### PR TITLE
[skip ci] code-format `__declspec` in title

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -187,7 +187,7 @@ which are supported by GCC, Clang, and other compilers.
 | weak                 |
 | weakreaf             |
 
-### MSVC __declspec
+### MSVC `__declspec`
 
 These values are supported using the MSVC style `__declspec` annotation,
 which are supported by MSVC, GCC, Clang, and other compilers.


### PR DESCRIPTION
I think it looks slightly better, and it also stops GitHub from rendering bold until the bottom in one view.